### PR TITLE
Fix healthcheck command in Docker Compose for PostgreSQL service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - safecity-network2
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_DATABASE}"]
       interval: 30s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This pull request includes a small update to the `docker-compose.yml` file, specifically improving the healthcheck configuration by using the correct environment variable names for the database username and database name.