### PR TITLE
Fix incidents relationship in User model to use 'reported_by' insteadof 'reporter_id'

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -77,6 +77,6 @@ class User extends Authenticatable
      */
     public function incidents(): HasMany
     {
-        return $this->hasMany(Incident::class, 'reporter_id', 'id');
+        return $this->hasMany(Incident::class, 'reported_by', 'id');
     }
 }


### PR DESCRIPTION
This pull request updates the relationship definition for the `incidents` method in the `User` model. The change ensures the foreign key used in the relationship matches the correct column name in the database.

* Updated the `incidents()` relationship in `app/Models/User.php` to use the `reported_by` foreign key instead of `reporter_id`, ensuring consistency with the database schema.